### PR TITLE
add JS Doc style comments to ElementMakerHTML Class 

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,14 @@
+/* * Class representing an HTML Element */
 class ElementMakerHTML {
+  /**
+   * Create and initialize an new HTML element
+   * @param {string} elementType - the type of element to be created. e.g. <li></li> (list item)
+   * @param {string} text - The text to be embedded in the html element e.g. <li>JS101 takes...</li>
+   * @param {string} parentElement - the parent element the child element belongs to e.g. <ul><li></li></ul>
+   * @param {string} id - the CSS id for that html element e.g. <ul id="courseList">
+   * @param {string} className - the CSS class name for an html element e.g. <button class="submitbutton">
+   * @param {string} placeholder - the place holder text for an element e.g. <input placeholder="How many...">
+   */
   constructor(elementType, text, parentElement, id, className, placeholder) {
     this.ele = document.createElement(elementType);
     this.textNode = document.createTextNode(text);
@@ -9,6 +19,9 @@ class ElementMakerHTML {
     if (placeholder) this.ele.placeholder = placeholder;
   }
 
+  /**
+   * Append the newly created HTML element to DOM tree
+   */
   appendElementToDOM() {
     this.parentElement.appendChild(this.ele);
   }


### PR DESCRIPTION
I added JSDoc comments to the "ElementMakerHTML" class to make it easy to document the source code, and for other contributors to be able to understand it quickly, so they can get up to speed. 

Here's a link to the JSDoc Specification `https://jsdoc.app/index.html`